### PR TITLE
fix permission denied errors whilst building the image

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -51,6 +51,8 @@ RUN service postgresql start && \
     sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='www-data'" | grep -q 1 || sudo -u postgres createuser -SDR www-data && \
     sudo -u postgres psql postgres -c "DROP DATABASE IF EXISTS nominatim" && \
     useradd -m -p password1234 nominatim && \
+    sudo chmod a+rx ./src/settings/settings.php  && \
+    sudo chmod a+rx ./src/settings/local.php  && \
     sudo -u nominatim ./src/utils/setup.php --osm-file /app/src/data.osm.pbf --all --threads 2 && \
     service postgresql stop
 


### PR DESCRIPTION
This PR will allow Docker build to finish successfully. Previously I got the following error log:
```
Step 19/23 : RUN service postgresql start &&     sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='nominatim'" | grep -q 1 || sudo -u postgres createuser -s nominatim &&     sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='www-data'" | grep -q 1 || sudo -u postgres createuser -SDR www-data &&     sudo -u postgres psql postgres -c "DROP DATABASE IF EXISTS nominatim" &&     useradd -m -p password1234 nominatim &&     sudo -u nominatim ./src/utils/setup.php --osm-file /app/src/data.osm.pbf --all --threads 2 &&     service postgresql stop
 ---> Running in 3bcb7c2bdac9
 * Starting PostgreSQL 9.3 database server
   ...done.
DROP DATABASE
NOTICE:  database "nominatim" does not exist, skipping
PHP Warning:  require_once(/app/src/settings/local.php): failed to open stream: Permission denied in /app/src/settings/settings.php on line 2
PHP Fatal error:  require_once(): Failed opening required '/app/src/settings/local.php' (include_path='.:/usr/share/php:/usr/share/pear') in /app/src/settings/settings.php on line 2
The command '/bin/sh -c service postgresql start &&     sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='nominatim'" | grep -q 1 || sudo -u postgres createuser -s nominatim &&     sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='www-data'" | grep -q 1 || sudo -u postgres createuser -SDR www-data &&     sudo -u postgres psql postgres -c "DROP DATABASE IF EXISTS nominatim" &&     useradd -m -p password1234 nominatim &&     sudo -u nominatim ./src/utils/setup.php --osm-file /app/src/data.osm.pbf --all --threads 2 &&     service postgresql stop' returned a non-zero code: 255
```